### PR TITLE
Use local labels to avoid duplicate assembly names

### DIFF
--- a/x86-64/neo-system-processor-implementation_for_architecture.adb
+++ b/x86-64/neo-system-processor-implementation_for_architecture.adb
@@ -612,26 +612,25 @@ package body Implementation_For_Architecture
       Result :         Integer_4_Unsigned     := 0;
       Data   : aliased Record_x86_Environment := (others => <>);
       begin
---          Asm(
---            ---------------------------------------------
---            "   fnstenv (%%eax)            " & END_LINE &
---            "   movl    8(%%eax),    %%eax " & END_LINE &
---            "   xor     $0xffffffff, %%eax " & END_LINE &
---            "   and     $0x0000ffff, %%eax " & END_LINE &
---            "   jz      empty              " & END_LINE &
---            "   movl    $0x00000000, %%eax " & END_LINE &
---            "   jmp     finished           " & END_LINE &
---            ---------------------------------------------
---            " empty:                       " & END_LINE &
---            "   movl    $0x00000001, %%eax " & END_LINE &
---            ---------------------------------------------
---            " finished:                    " & END_LINE ,
---            ---------------------------------------------
---            Volatile => True,
---            Inputs   => Address'Asm_Input(TO_EAX, Data'Address),
---            Outputs  => Integer_4_Unsigned'Asm_Output(FROM_EAX, Result));
---          return Result /= 0;
-return false;
+        Asm(
+          ---------------------------------------------
+          "   fnstenv (%%eax)            " & END_LINE &
+          "   movl    8(%%eax),    %%eax " & END_LINE &
+          "   xor     $0xffffffff, %%eax " & END_LINE &
+          "   and     $0x0000ffff, %%eax " & END_LINE &
+          "   jz      1f                 " & END_LINE &
+          "   movl    $0x00000000, %%eax " & END_LINE &
+          "   jmp     2f                 " & END_LINE &
+          ---------------------------------------------
+          " 1:                           " & END_LINE &
+          "   movl    $0x00000001, %%eax " & END_LINE &
+          ---------------------------------------------
+          " 2:                       " & END_LINE ,
+          ---------------------------------------------
+          Volatile => True,
+          Inputs   => Address'Asm_Input(TO_EAX, Data'Address),
+          Outputs  => Integer_4_Unsigned'Asm_Output(FROM_EAX, Result));
+        return Result /= 0;
     end Is_Stack_Empty;
   -----------------
   -- Clear_Stack --
@@ -640,26 +639,25 @@ return false;
       is
       Data : aliased Record_x86_Environment := (others => <>);
       begin
---          Asm(
---            ---------------------------------------------
---            "   fnstenv (%%eax)            " & END_LINE &
---            "   movl    8(%%eax),    %%eax " & END_LINE &
---            "   xor     $0xffffffff, %%eax " & END_LINE &
---            "   movl    $0x0000c000, %%edx " & END_LINE &
---            ---------------------------------------------
---            " emptystack:                  " & END_LINE &
---            "   movl    %%eax,       %%ecx " & END_LINE &
---            "   and     %%ecx,       %%edx " & END_LINE &
---            "   jz      cease              " & END_LINE &
---            "   fstp    %%st               " & END_LINE &
---            "   shr     $2,          %%edx " & END_LINE &
---            "   jmp     emptystack         " & END_LINE &
---            ---------------------------------------------
---            " cease:                       " & END_LINE ,
---            ---------------------------------------------
---            Volatile => True,
---            Inputs   => Address'Asm_Input(TO_EAX, Data'Address));
-null;
+              Asm(
+                ---------------------------------------------
+                "   fnstenv (%%eax)            " & END_LINE &
+                "   movl    8(%%eax),    %%eax " & END_LINE &
+                "   xor     $0xffffffff, %%eax " & END_LINE &
+                "   movl    $0x0000c000, %%edx " & END_LINE &
+                ---------------------------------------------
+                " 1:                           " & END_LINE &
+                "   movl    %%eax,       %%ecx " & END_LINE &
+                "   and     %%ecx,       %%edx " & END_LINE &
+                "   jz      1f                 " & END_LINE &
+                "   fstp    %%st               " & END_LINE &
+                "   shr     $2,          %%edx " & END_LINE &
+                "   jmp     1b                 " & END_LINE &
+                ---------------------------------------------
+                " 2:                           " & END_LINE ,
+                ---------------------------------------------
+                Volatile => True,
+                Inputs   => Address'Asm_Input(TO_EAX, Data'Address));
       end Clear_Stack;
   ---------------
   -- Put_Trace --


### PR DESCRIPTION
Note: This has been compile-tested only.
