### PR TITLE
Fix syntax error in neo-system-processor-implementation_for_architecture.adb

### DIFF
--- a/Code/x86-64/neo-system-processor-implementation_for_architecture.adb
+++ b/Code/x86-64/neo-system-processor-implementation_for_architecture.adb
@@ -259,7 +259,7 @@ package body Implementation_For_Architecture
             declare
             type Array_Save_Area
               is array(1..512)
-              of Integer_1_Unsigned;
+              of Integer_1_Unsigned
               with Alignment => 16;
             Save_Area : aliased Array_Save_Area := (others => 0);
             begin

--- a/adadoom3.gpr
+++ b/adadoom3.gpr
@@ -59,7 +59,7 @@ project AdaDoom3 is
     -- multiple lines used to increase readability.
     case System is
       when "Windows" => Separator := "\";
-      when "MacOS"   => Separator := ":";
+      -- when "MacOS"   => Separator := ":";
       when "Linux"   => Separator := "/";
     end case;
 


### PR DESCRIPTION
The semicolon should not be there.
Fix adadoom3.gpr MacOS was commented out from the options but still referred in
the case statement.
