### PR TITLE
hidden -> display:none for ie10

### DIFF
--- a/runsdk.hta
+++ b/runsdk.hta
@@ -438,7 +438,7 @@
           <icon kind="run"></icon> Run {{description}}
         </button>
         <form name="configure">
-          <input hidden="true" type="file"
+          <input style="display:none;" type="file"
             name="pathBrowse" accept="application/octet-stream" onchange="this.form.pathInput.value = this.value"/>
           <input type="text" name="pathInput" for="{{name}}" placeholder="{{placeholder}}"/>
           <button class="browse-button" type="button" onclick="this.form.pathBrowse.click()">


### PR DESCRIPTION
This change allows it to work correctly on IE10. The hidden attribute wasn't causing the file input to be hidden.